### PR TITLE
sorting glyph pickle folders

### DIFF
--- a/notebooks/read-and-evaluate-trained-model.ipynb
+++ b/notebooks/read-and-evaluate-trained-model.ipynb
@@ -33,7 +33,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%run udacity-tensorflow-support.py"
@@ -74,6 +76,7 @@
     "\n",
     "glyph_dir = Path.cwd().joinpath(dir_name)\n",
     "test_folders = [glyph_dir.joinpath(i) for i in glyph_dir.iterdir()]\n",
+    "test_folders.sort()\n",
     "test_datasets = maybe_pickle(test_folders, 2) # provide only 2 samples for now\n",
     "test_dataset, test_labels = merge_datasets(test_datasets, 20)\n",
     "test_dataset, test_labels = randomize(test_dataset, test_labels)\n",
@@ -200,8 +203,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -215,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some systems (MacOS) do not sort directory listing used to format the test data set.  The ordering must be alphabetical to infer the labels.